### PR TITLE
Arreglar shellcheck warnings

### DIFF
--- a/zram.sh
+++ b/zram.sh
@@ -4,13 +4,13 @@ modprobe zram num_devices=$cores
 
 swapoff -a
 
-totalmem=`free | grep -e "^Mem:" | awk '{print $2}'`
-mem=$(( ($totalmem / $cores)* 1024 ))
+totalmem=$(free | grep -e "^Mem:" | awk '{print $2}')
+mem=$(( (totalmem / cores)* 1024 ))
 
 core=0
 while [ $core -lt $cores ]; do
   echo $mem > /sys/block/zram$core/disksize
   mkswap /dev/zram$core
   swapon -p 5 /dev/zram$core
-  let core=core+1
+  (( core++ ))
 done


### PR DESCRIPTION
SC2004 $/${} is unnecessary on arithmetic variables.
SC2006 Use $(...) notation instead of legacy backticked `...`.
SC2219 Instead of let expr, prefer (( expr )) .